### PR TITLE
Update Sandwich SDK to 7.5.0

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -69,7 +69,7 @@
                 <param name="android-package" value="com.qonversion.android.sdk.NoCodesPlugin"/>
             </feature>
         </config-file>
-        <framework src="io.qonversion:sandwich:7.4.0" />
+        <framework src="io.qonversion:sandwich:7.5.0" />
         <source-file src="src/android/NoCodesPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/QonversionPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/EntitiesConverter.java" target-dir="src/com/qonversion/android/sdk" />
@@ -95,7 +95,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="QonversionSandwich" spec="7.4.0" />
+                <pod name="QonversionSandwich" spec="7.5.0" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
## Summary
- Update Sandwich SDK dependency to version 7.5.0

## Test plan
- [ ] Build the SDK
- [ ] Run sample app and verify basic functionality