### PR TITLE
Rename Android deferred purchase handler arg to purchaseResult

### DIFF
--- a/plugin/src/android/QonversionPlugin.java
+++ b/plugin/src/android/QonversionPlugin.java
@@ -260,10 +260,10 @@ public class QonversionPlugin extends AnnotatedCordovaPlugin implements Qonversi
     }
 
     @Override
-    public void onDeferredPurchaseCompleted(@NonNull Map<String, ?> map) {
+    public void onDeferredPurchaseCompleted(@NonNull Map<String, ?> purchaseResult) {
         if (deferredPurchasesDelegate != null) {
             try {
-                final JSONObject payload = EntitiesConverter.convertMapToJson(map);
+                final JSONObject payload = EntitiesConverter.convertMapToJson(purchaseResult);
                 PluginResult result = new PluginResult(PluginResult.Status.OK, payload);
                 result.setKeepCallback(true);
                 deferredPurchasesDelegate.sendPluginResult(result);


### PR DESCRIPTION
## Summary
- Rename the `onDeferredPurchaseCompleted` parameter in `QonversionPlugin.java` from `map` to `purchaseResult`, matching iOS's `qonversionDidCompleteDeferredPurchase:` parameter name.

Addresses point 4 from the review on #152: https://github.com/qonversion/cordova-plugin/pull/152#issuecomment-4287827318

## Test plan
- [ ] Android build still succeeds.