### PR TITLE
Fix self-referential JSDoc on setDeferredPurchasesListener

### DIFF
--- a/plugin/src/plugin/QonversionApi.ts
+++ b/plugin/src/plugin/QonversionApi.ts
@@ -270,9 +270,8 @@ export interface QonversionApi {
    * such as SCA (Strong Customer Authentication), Ask to Buy, or other pending transactions.
    * This listener will be called when such purchases are finalized.
    *
-   * You may set this listener both *after* Qonversion SDK initializing
-   * with {@link QonversionApi.setDeferredPurchasesListener} and *while* Qonversion initializing
-   * with {@link Qonversion.initialize}.
+   * You may set this listener *after* Qonversion SDK initialization using this method,
+   * or *during* Qonversion initialization via {@link QonversionConfigBuilder.setDeferredPurchasesListener}.
    *
    * @param listener listener to be called when a deferred purchase completes
    */


### PR DESCRIPTION
## Summary
- Correct the JSDoc on `setDeferredPurchasesListener` in `QonversionApi.ts`. Previously it self-linked to the method being documented and pointed the config-time path at `Qonversion.initialize` instead of the builder method. Also tightened "initializing" to "initialization".

Addresses point 5 from the review on #152: https://github.com/qonversion/cordova-plugin/pull/152#issuecomment-4287827318

## Test plan
- [ ] TypeScript compiles.