### PR TITLE
Register deferred purchases channel before initializeSdk

### DIFF
--- a/plugin/src/plugin/QonversionInternal.ts
+++ b/plugin/src/plugin/QonversionInternal.ts
@@ -42,6 +42,18 @@ export default class QonversionInternal implements QonversionApi {
 
   constructor(qonversionConfig: QonversionConfig) {
     callQonversionNative('storeSDKInfo', ['cordova', sdkVersion]).then(noop);
+    subscribeOnQonversionNativeEvents<QPurchaseResult>(
+      'subscribeDeferredPurchases',
+      (event) => {
+        if (this.deferredPurchasesListener) {
+          const purchaseResult = Mapper.convertPurchaseResult(event);
+          if (purchaseResult) {
+            this.deferredPurchasesListener.onDeferredPurchaseCompleted(purchaseResult);
+          }
+        }
+      }
+    );
+
     subscribeOnQonversionNativeEvents<Record<string, QEntitlement>>(
       'initializeSdk',
       (event) => {
@@ -58,18 +70,6 @@ export default class QonversionInternal implements QonversionApi {
         qonversionConfig.proxyUrl,
         qonversionConfig.kidsMode
       ]
-    );
-
-    subscribeOnQonversionNativeEvents<QPurchaseResult>(
-      'subscribeDeferredPurchases',
-      (event) => {
-        if (this.deferredPurchasesListener) {
-          const purchaseResult = Mapper.convertPurchaseResult(event);
-          if (purchaseResult) {
-            this.deferredPurchasesListener.onDeferredPurchaseCompleted(purchaseResult);
-          }
-        }
-      }
     );
 
     this.entitlementsUpdateListener = qonversionConfig.entitlementsUpdateListener;


### PR DESCRIPTION
## Summary
- Swap the order of `subscribeOnQonversionNativeEvents` calls in `QonversionInternal` constructor so the `subscribeDeferredPurchases` channel is registered before `initializeSdk`.
- `initializeSdk` triggers Sandwich launch on the native side; registering the deferred delegate first closes a theoretical window where early `qonversionDidCompleteDeferredPurchase` events would be dropped by the null guard.

Addresses point 2 from the review on #152: https://github.com/qonversion/cordova-plugin/pull/152#issuecomment-4287827318

## Test plan
- [ ] Manual iOS run: deferred purchase fires, listener receives the event.
- [ ] Manual Android run: deferred purchase fires, listener receives the event.