### PR TITLE
Remove superfluous DeferredPurchasesListener js-module entry

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -27,7 +27,6 @@
     <js-module src="www/NoCodesError.js" name="NoCodesError" />
     <js-module src="www/NoCodesListener.js" name="NoCodesListener" />
     <js-module src="www/PurchaseDelegate.js" name="PurchaseDelegate" />
-    <js-module src="www/DeferredPurchasesListener.js" name="DeferredPurchasesListener" />
     <js-module src="www/Entitlement.js" name="Entitlement" />
     <js-module src="www/Transaction.js" name="Transaction" />
     <js-module src="www/IntroEligibility.js" name="IntroEligibility" />


### PR DESCRIPTION
## Summary
- Remove the `<js-module>` entry for `DeferredPurchasesListener` in `plugin.xml`. It's a pure TypeScript interface that compiles to an essentially empty JS file, and its peers `EntitlementsUpdateListener` and `PromoPurchasesListener` are not registered. The entry is a no-op and inconsistent.

Addresses point 3 from the review on #152: https://github.com/qonversion/cordova-plugin/pull/152#issuecomment-4287827318

## Test plan
- [ ] `cordova plugin add` still succeeds.
- [ ] SDK init still works on both platforms.