### PR TITLE
Bridge No-Codes loadScreen, defaultVariables and custom action event (DEV-1190)

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -26,6 +26,7 @@
     <js-module src="www/NoCodesAction.js" name="NoCodesAction" />
     <js-module src="www/NoCodesError.js" name="NoCodesError" />
     <js-module src="www/NoCodesListener.js" name="NoCodesListener" />
+    <js-module src="www/NoCodesScreen.js" name="NoCodesScreen" />
     <js-module src="www/PurchaseDelegate.js" name="PurchaseDelegate" />
     <js-module src="www/Entitlement.js" name="Entitlement" />
     <js-module src="www/Transaction.js" name="Transaction" />
@@ -69,7 +70,7 @@
                 <param name="android-package" value="com.qonversion.android.sdk.NoCodesPlugin"/>
             </feature>
         </config-file>
-        <framework src="io.qonversion:sandwich:7.9.0" />
+        <framework src="io.qonversion:sandwich:7.10.1" />
         <source-file src="src/android/NoCodesPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/QonversionPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/EntitiesConverter.java" target-dir="src/com/qonversion/android/sdk" />
@@ -95,7 +96,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="QonversionSandwich" spec="7.9.0" />
+                <pod name="QonversionSandwich" spec="7.10.1" />
             </pods>
         </podspec>
     </platform>

--- a/plugin/src/android/NoCodesPlugin.java
+++ b/plugin/src/android/NoCodesPlugin.java
@@ -99,6 +99,11 @@ public class NoCodesPlugin extends AnnotatedCordovaPlugin implements NoCodesEven
         callbackContext.success();
     }
 
+    @PluginAction(thread = ExecutionThread.UI, actionName = "loadScreen", isAutofinish = false)
+    public void loadScreen(String contextKey, CallbackContext callbackContext) {
+        noCodesSandwich.loadScreen(contextKey, Utils.getResultListener(callbackContext));
+    }
+
     @PluginAction(thread = ExecutionThread.UI, actionName = "close")
     public void close(CallbackContext callbackContext) {
         noCodesSandwich.close();

--- a/plugin/src/ios/CDVNoCodesPlugin.h
+++ b/plugin/src/ios/CDVNoCodesPlugin.h
@@ -12,6 +12,7 @@
 - (void)subscribePurchase:(CDVInvokedUrlCommand *)command;
 - (void)subscribeRestore:(CDVInvokedUrlCommand *)command;
 - (void)showScreen:(CDVInvokedUrlCommand *)command;
+- (void)loadScreen:(CDVInvokedUrlCommand *)command;
 - (void)close:(CDVInvokedUrlCommand *)command;
 - (void)setScreenPresentationConfig:(CDVInvokedUrlCommand *)command;
 - (void)setLocale:(CDVInvokedUrlCommand *)command;

--- a/plugin/src/ios/CDVNoCodesPlugin.m
+++ b/plugin/src/ios/CDVNoCodesPlugin.m
@@ -105,6 +105,16 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)loadScreen:(CDVInvokedUrlCommand *)command {
+    NSString *contextKey = [command argumentAtIndex:0];
+    __block __weak CDVNoCodesPlugin *weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [weakSelf.noCodesSandwich loadScreen:contextKey completion:^(NSDictionary<NSString *,id> * _Nullable result, SandwichError * _Nullable error) {
+            [QCUtils returnCordovaResult:result error:error command:command delegate:weakSelf.commandDelegate];
+        }];
+    });
+}
+
 - (void)close:(CDVInvokedUrlCommand *)command {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.noCodesSandwich close];

--- a/plugin/src/ios/CDVNoCodesPlugin.m
+++ b/plugin/src/ios/CDVNoCodesPlugin.m
@@ -107,10 +107,11 @@
 
 - (void)loadScreen:(CDVInvokedUrlCommand *)command {
     NSString *contextKey = [command argumentAtIndex:0];
-    __block __weak CDVNoCodesPlugin *weakSelf = self;
+    // Strong self on purpose: the one-shot completion must outlive navigation so the
+    // JS promise always settles; the block is not retained by the plugin, so no cycle.
     dispatch_async(dispatch_get_main_queue(), ^{
-        [weakSelf.noCodesSandwich loadScreen:contextKey completion:^(NSDictionary<NSString *,id> * _Nullable result, SandwichError * _Nullable error) {
-            [QCUtils returnCordovaResult:result error:error command:command delegate:weakSelf.commandDelegate];
+        [self.noCodesSandwich loadScreen:contextKey completion:^(NSDictionary<NSString *,id> * _Nullable result, SandwichError * _Nullable error) {
+            [QCUtils returnCordovaResult:result error:error command:command delegate:self.commandDelegate];
         }];
     });
 }

--- a/plugin/src/plugin/Mapper.ts
+++ b/plugin/src/plugin/Mapper.ts
@@ -23,6 +23,7 @@ import {
   QonversionErrorCode,
   PurchaseResultStatus,
   PurchaseResultSource,
+  NoCodesScreenVariableKind,
 } from "./enums";
 import {IntroEligibility} from "./IntroEligibility";
 import {Offering} from "./Offering";
@@ -33,6 +34,7 @@ import {SKProduct} from "./SKProduct";
 import {SKProductDiscount} from "./SKProductDiscount";
 import {SKSubscriptionPeriod} from "./SKSubscriptionPeriod";
 import {NoCodesAction} from "./NoCodesAction";
+import {NoCodesScreen, NoCodesScreenVariable} from "./NoCodesScreen";
 import {NoCodesError} from "./NoCodesError";
 import {QonversionError} from "./QonversionError";
 import {User} from './User';
@@ -1013,6 +1015,34 @@ class Mapper {
       payload["parameters"],
       this.convertNoCodesError(payload["error"])
     );
+  }
+
+  static convertScreen(
+    payload: Record<string, any>
+  ): NoCodesScreen {
+    const rawVariables: Record<string, any>[] = payload["defaultVariables"] ?? [];
+    const variables = rawVariables.map(variable => new NoCodesScreenVariable(
+      this.convertScreenVariableKind(variable["kind"]),
+      variable["key"],
+      variable["type"],
+      variable["value"] ?? null,
+      variable["stringValue"] ?? "",
+    ));
+    return new NoCodesScreen(
+      payload["id"],
+      payload["contextKey"],
+      payload["defaultSelectedProductId"] ?? undefined,
+      variables,
+    );
+  }
+
+  static convertScreenVariableKind(kind: string | undefined): NoCodesScreenVariableKind {
+    switch (kind) {
+      case NoCodesScreenVariableKind.CUSTOM: return NoCodesScreenVariableKind.CUSTOM;
+      case NoCodesScreenVariableKind.PRODUCT: return NoCodesScreenVariableKind.PRODUCT;
+      case NoCodesScreenVariableKind.SELECTED_PRODUCT: return NoCodesScreenVariableKind.SELECTED_PRODUCT;
+      default: return NoCodesScreenVariableKind.UNKNOWN;
+    }
   }
 
   static convertNoCodesError(

--- a/plugin/src/plugin/Mapper.ts
+++ b/plugin/src/plugin/Mapper.ts
@@ -1101,6 +1101,7 @@ class Mapper {
       case NoCodesErrorCode.RATE_LIMIT_EXCEEDED: return NoCodesErrorCode.RATE_LIMIT_EXCEEDED;
       case NoCodesErrorCode.SCREEN_LOADING_FAILED: return NoCodesErrorCode.SCREEN_LOADING_FAILED;
       case NoCodesErrorCode.SDK_INITIALIZATION_ERROR: return NoCodesErrorCode.SDK_INITIALIZATION_ERROR;
+      case NoCodesErrorCode.CLIENT_ERROR: return NoCodesErrorCode.CLIENT_ERROR;
     }
 
     return NoCodesErrorCode.UNKNOWN;

--- a/plugin/src/plugin/NoCodesApi.ts
+++ b/plugin/src/plugin/NoCodesApi.ts
@@ -1,5 +1,6 @@
 import {PurchaseDelegate} from './PurchaseDelegate';
 import {ScreenPresentationConfig} from './ScreenPresentationConfig';
+import {NoCodesScreen} from './NoCodesScreen';
 import {NoCodesTheme} from './enums';
 
 export interface NoCodesApi {
@@ -19,6 +20,19 @@ export interface NoCodesApi {
    *                        to the provided contextKey and only applied to that screen.
    */
   showScreen(contextKey: string, customVariables?: Record<string, string>): void;
+
+  /**
+   * Load a No-Code screen (from cache or network) without presenting it, so you can decide
+   * whether to present it or show your own fallback UI before any SDK screen appears.
+   * Present the screen with {@link showScreen} — the loaded content is served from cache.
+   *
+   * The returned {@link NoCodesScreen} exposes the typed default variables configured
+   * in the builder and the default selected product id.
+   *
+   * @param contextKey the context key of the screen to load.
+   * @returns the loaded screen data.
+   */
+  loadScreen(contextKey: string): Promise<NoCodesScreen>;
 
   /**
    * Close the current opened No-Code screen.

--- a/plugin/src/plugin/NoCodesInternal.ts
+++ b/plugin/src/plugin/NoCodesInternal.ts
@@ -54,8 +54,15 @@ export default class NoCodesInternal implements NoCodesApi {
   }
 
   async loadScreen(contextKey: string): Promise<NoCodesScreen> {
-    const screenData = await callNoCodesNative<Record<string, any>>('loadScreen', [contextKey]);
-    return Mapper.convertScreen(screenData);
+    try {
+      const screenData = await callNoCodesNative<Record<string, any>>('loadScreen', [contextKey]);
+      return Mapper.convertScreen(screenData);
+    } catch (rawError) {
+      const error = typeof rawError === 'object' && rawError !== null
+        ? Mapper.convertNoCodesError(rawError as Record<string, any>)
+        : undefined;
+      throw error ?? rawError;
+    }
   }
 
   async close(): Promise<void> {

--- a/plugin/src/plugin/NoCodesInternal.ts
+++ b/plugin/src/plugin/NoCodesInternal.ts
@@ -1,6 +1,7 @@
 import {NoCodesListener} from "./NoCodesListener";
 import {PurchaseDelegate} from "./PurchaseDelegate";
 import Mapper, {QNoCodeEvent, QProduct} from "./Mapper";
+import {NoCodesScreen} from './NoCodesScreen';
 import {NoCodesApi} from './NoCodesApi';
 import {NoCodesConfig} from './NoCodesConfig';
 import {ScreenPresentationConfig} from './ScreenPresentationConfig';
@@ -14,6 +15,7 @@ const EVENT_ACTION_STARTED = "nocodes_action_started";
 const EVENT_ACTION_FAILED = "nocodes_action_failed";
 const EVENT_ACTION_FINISHED = "nocodes_action_finished";
 const EVENT_SCREEN_FAILED_TO_LOAD = "nocodes_screen_failed_to_load";
+const EVENT_CUSTOM_ACTION = "nocodes_custom_action";
 
 const SDK_VERSION = "1.0.0";
 const SDK_SOURCE = "cordova";
@@ -49,6 +51,11 @@ export default class NoCodesInternal implements NoCodesApi {
 
   async showScreen(contextKey: string, customVariables?: Record<string, string>): Promise<void> {
     return await callNoCodesNative('showScreen', [contextKey, customVariables ?? null]);
+  }
+
+  async loadScreen(contextKey: string): Promise<NoCodesScreen> {
+    const screenData = await callNoCodesNative<Record<string, any>>('loadScreen', [contextKey]);
+    return Mapper.convertScreen(screenData);
   }
 
   async close(): Promise<void> {
@@ -94,6 +101,10 @@ export default class NoCodesInternal implements NoCodesApi {
       case EVENT_ACTION_FINISHED:
         const actionFinished = Mapper.convertAction(event.payload);
         this.noCodesListener?.onActionFinishedExecuting(actionFinished);
+        break;
+      case EVENT_CUSTOM_ACTION:
+        const value = event.payload?.value ?? "";
+        this.noCodesListener?.onCustomAction?.(value);
         break;
       case EVENT_FINISHED:
         this.noCodesListener?.onFinished();

--- a/plugin/src/plugin/NoCodesListener.ts
+++ b/plugin/src/plugin/NoCodesListener.ts
@@ -27,6 +27,18 @@ export interface NoCodesListener {
     onActionFinishedExecuting: (action: NoCodesAction) => void;
 
     /**
+     * Called when a custom action configured in the builder is triggered on the screen.
+     * The No-Codes SDK does not execute anything itself — handle the value in your app code.
+     * The screen stays open; close it using {@link NoCodesApi.close} if needed.
+     *
+     * Optional to keep existing listener implementations source-compatible.
+     *
+     * @param value the string value configured for the custom action in the builder,
+     * or an empty string if no value was configured
+     */
+    onCustomAction?: (value: string) => void;
+
+    /**
      * Called when No-Codes flow is finished
      */
     onFinished: () => void;

--- a/plugin/src/plugin/NoCodesScreen.ts
+++ b/plugin/src/plugin/NoCodesScreen.ts
@@ -1,0 +1,110 @@
+import {NoCodesScreenVariableKind} from './enums';
+
+/**
+ * A typed default variable of a No-Codes screen, configured in the builder and delivered
+ * at screen load so it can be read by key. The value keeps its authored type
+ * (boolean / string / number) rather than being coerced to a string.
+ */
+export class NoCodesScreenVariable {
+  /**
+   * What the variable represents — see {@link NoCodesScreenVariableKind}.
+   */
+  kind: NoCodesScreenVariableKind;
+
+  /**
+   * Variable name it is addressed by (`variable.<key>` in the builder for custom
+   * variables, the slot name for product slots). May contain spaces.
+   */
+  key: string;
+
+  /**
+   * Authored value type: `"boolean"`, `"string"` or `"number"`.
+   */
+  type: string;
+
+  /**
+   * The configured default value, preserving its native type.
+   * Null when no default value was authored.
+   */
+  value: boolean | string | number | null;
+
+  /**
+   * The value rendered as a plain string regardless of its native type: `"true"`/`"false"`
+   * for booleans, the string itself, a number without a trailing `.0` when integral,
+   * or an empty string when no value was authored.
+   */
+  stringValue: string;
+
+  constructor(
+    kind: NoCodesScreenVariableKind,
+    key: string,
+    type: string,
+    value: boolean | string | number | null,
+    stringValue: string,
+  ) {
+    this.kind = kind;
+    this.key = key;
+    this.type = type;
+    this.value = value;
+    this.stringValue = stringValue;
+  }
+}
+
+/**
+ * A loaded No-Codes screen returned from {@link NoCodesApi.loadScreen}.
+ *
+ * Exposes the screen identifiers and the typed default variables configured in the builder —
+ * the screen content stays internal, as rendering remains the SDK's job via
+ * {@link NoCodesApi.showScreen}.
+ */
+export class NoCodesScreen {
+  /**
+   * Identifier of the screen.
+   */
+  id: string;
+
+  /**
+   * The context key of the screen set in the No-Codes builder.
+   */
+  contextKey: string;
+
+  /**
+   * The Qonversion product id selected by default when the screen opens (the builder's
+   * Default Product), or undefined when none is configured.
+   */
+  defaultSelectedProductId: string | undefined;
+
+  /**
+   * Typed default variables of the screen configured in the builder: authored custom
+   * variables and product slots. Read them by {@link NoCodesScreenVariable.key} (may be empty).
+   */
+  defaultVariables: NoCodesScreenVariable[];
+
+  constructor(
+    id: string,
+    contextKey: string,
+    defaultSelectedProductId: string | undefined,
+    defaultVariables: NoCodesScreenVariable[],
+  ) {
+    this.id = id;
+    this.contextKey = contextKey;
+    this.defaultSelectedProductId = defaultSelectedProductId;
+    this.defaultVariables = defaultVariables;
+  }
+
+  /**
+   * Returns the default variable configured under the given key, or undefined when the screen
+   * has no variable with that exact (case-sensitive) key.
+   *
+   * Keys are only unique within a kind — a custom variable and a product slot may share a
+   * name — so pass `kind` to disambiguate; without it the first match in payload order
+   * (custom variables, then product slots, then the selected product) is returned.
+   *
+   * For the default selected product prefer {@link defaultSelectedProductId} — it needs no key.
+   */
+  defaultVariable(key: string, kind?: NoCodesScreenVariableKind): NoCodesScreenVariable | undefined {
+    return this.defaultVariables.find(
+      variable => variable.key === key && (kind === undefined || variable.kind === kind)
+    );
+  }
+}

--- a/plugin/src/plugin/enums.ts
+++ b/plugin/src/plugin/enums.ts
@@ -344,7 +344,8 @@ export enum NoCodesErrorCode {
   PRODUCTS_LOADING_FAILED = "ProductsLoadingFailed", // iOS
   RATE_LIMIT_EXCEEDED = "RateLimitExceeded", // iOS
   SCREEN_LOADING_FAILED = "ScreenLoadingFailed", // iOS
-  SDK_INITIALIZATION_ERROR = "SDKInitializationError" // iOS
+  SDK_INITIALIZATION_ERROR = "SDKInitializationError", // iOS
+  CLIENT_ERROR = "ClientError"
 }
 
 /**

--- a/plugin/src/plugin/enums.ts
+++ b/plugin/src/plugin/enums.ts
@@ -449,3 +449,32 @@ export enum NoCodesTheme {
    */
   DARK = "dark",
 }
+
+/**
+ * Kind of a No-Codes screen default variable — what it was configured as in the builder.
+ * The set may grow in future backend versions; values this SDK version does not know
+ * are mapped to {@link NoCodesScreenVariableKind.UNKNOWN} instead of failing.
+ */
+export enum NoCodesScreenVariableKind {
+  /**
+   * A Screen Variable authored in the builder's Variables section.
+   */
+  CUSTOM = "custom",
+
+  /**
+   * A product slot: the variable key is the slot name and the value is the default
+   * Qonversion product id assigned to it.
+   */
+  PRODUCT = "product",
+
+  /**
+   * The screen's Default Product configured in the builder: the value is
+   * the Qonversion product id selected by default.
+   */
+  SELECTED_PRODUCT = "selected_product",
+
+  /**
+   * A kind introduced on the backend after this SDK version was released.
+   */
+  UNKNOWN = "unknown",
+}

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -33,7 +33,7 @@
     fastq "^1.6.0"
 
 "@qonversion/cordova-plugin@file:../plugin":
-  version "7.0.0"
+  version "7.6.0"
   resolved "file:../plugin"
 
 "@xmldom/xmldom@^0.8.8":
@@ -225,7 +225,7 @@ cordova-plugin-device@^3.0.0:
   integrity sha512-g8fFYOvleeYpklWvHwZ/T8/IzJe/3O0MGVDIUoqBru4v8SNDAbNVD3oOqoOQANBWGFQMg7GIkAAl8errCHZ7zQ==
 
 "cordova-plugin-qonversion@file:../plugin":
-  version "7.0.0"
+  version "7.6.0"
   resolved "file:../plugin"
 
 cross-spawn@^7.0.1, cross-spawn@^7.0.3, cross-spawn@^7.0.6:


### PR DESCRIPTION
Brings the No-Codes API from sandwich **7.10.1** (native iOS 6.13.0 / Android nocodes 1.10.0) into the Cordova layer.

[DEV-1190](https://linear.app/qonversion/issue/DEV-1190/cordova-no-codes-loadscreen-defaultvariables-and-custom-action-event)

## Changes
- Sandwich bump 7.9.0 → **7.10.1** (plugin.xml: gradle framework + pod).
- `NoCodes.loadScreen(contextKey): Promise<NoCodesScreen>` — load-before-present; the screen model exposes `id`, `contextKey`, `defaultSelectedProductId` and typed `defaultVariables` (`kind/key/type/value/stringValue`) with a `defaultVariable(key, kind?)` lookup mirroring the native SDKs. Presenting stays on `showScreen` (served from cache). New `www/NoCodesScreen.js` js-module registered in plugin.xml.
- New `nocodes_custom_action` event → **optional** `onCustomAction(value)` callback on `NoCodesListener` (native event envelope is generic, so natives only needed the `loadScreen` handlers: iOS via `QCUtils returnCordovaResult`, Android via `Utils.getResultListener`, both on the sandwich completion).

## Verification
- `yarn build` (tsc → www/) ✅ — the CI publish gate
- Sample Android build against sandwich 7.10.1 — running, will report in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEJXqfVNxqoUcKXhSPhWn