### PR TITLE
chore: deprecate public Offerings API

### DIFF
--- a/plugin/src/plugin/QonversionApi.ts
+++ b/plugin/src/plugin/QonversionApi.ts
@@ -71,7 +71,7 @@ export interface QonversionApi {
    *
    * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
    *
-   * @see [Migrate offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
+   * @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
    */
   offerings(): Promise<Offerings | null>;
 

--- a/plugin/src/plugin/QonversionApi.ts
+++ b/plugin/src/plugin/QonversionApi.ts
@@ -69,7 +69,9 @@ export interface QonversionApi {
    *
    * @returns the promise with Qonversion offerings
    *
-   * @see [Offerings](https://qonversion.io/docs/offerings) for more details
+   * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
+   *
+   * @see [Migrate offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
    */
   offerings(): Promise<Offerings | null>;
 

--- a/plugin/src/plugin/QonversionInternal.ts
+++ b/plugin/src/plugin/QonversionInternal.ts
@@ -140,6 +140,11 @@ export default class QonversionInternal implements QonversionApi {
     return mappedProducts;
   }
 
+  /**
+   * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
+   *
+   * @see [Migrate offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
+   */
   async offerings(): Promise<Offerings | null> {
     let offerings = await callQonversionNative<QOfferings>('offerings');
     // noinspection UnnecessaryLocalVariableJS

--- a/plugin/src/plugin/QonversionInternal.ts
+++ b/plugin/src/plugin/QonversionInternal.ts
@@ -143,7 +143,7 @@ export default class QonversionInternal implements QonversionApi {
   /**
    * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
    *
-   * @see [Migrate offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
+   * @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
    */
   async offerings(): Promise<Offerings | null> {
     let offerings = await callQonversionNative<QOfferings>('offerings');


### PR DESCRIPTION
## Summary

Marks the public **Offerings API** as `@deprecated` in the Cordova plugin. Offerings are a legacy Qonversion feature that has been sunset in favor of **Remote Configs**, which manage paywall products remotely without app updates.

This is a documentation/annotation-only change — **behavior is unchanged**. The `offerings()` method continues to work exactly as before; developers now see an IDE deprecation warning pointing to the migration guide.

## Changes

- `plugin/src/plugin/QonversionApi.ts` — added `@deprecated` JSDoc to the `offerings()` interface method.
- `plugin/src/plugin/QonversionInternal.ts` — added `@deprecated` JSDoc to the `offerings()` implementation.
- Replaced the outdated `@see [Offerings](https://qonversion.io/docs/offerings)` link with the migration guide URL.

DTOs (`Offerings`, `Offering`) are intentionally **not** deprecated — they remain valid return types.

## Migration guide

https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs

## Related

- documentation_mintlify#100
- dash-mono#571

> Note: this PR is intentionally left open for review — do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
