### PR TITLE
DEV-1215: expose purchaseOptionId on Product

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -70,7 +70,7 @@
                 <param name="android-package" value="com.qonversion.android.sdk.NoCodesPlugin"/>
             </feature>
         </config-file>
-        <framework src="io.qonversion:sandwich:7.10.1" />
+        <framework src="io.qonversion:sandwich:7.11.0" />
         <source-file src="src/android/NoCodesPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/QonversionPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/EntitiesConverter.java" target-dir="src/com/qonversion/android/sdk" />
@@ -96,7 +96,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="QonversionSandwich" spec="7.10.1" />
+                <pod name="QonversionSandwich" spec="7.11.0" />
             </pods>
         </podspec>
     </platform>

--- a/plugin/src/plugin/Mapper.ts
+++ b/plugin/src/plugin/Mapper.ts
@@ -75,6 +75,7 @@ export type QProduct = {
 
 type QProductStoreDetails = {
   basePlanId?: string | null,
+  purchaseOptionId?: string | null,
   productId: string,
   name: string,
   title: string
@@ -879,6 +880,7 @@ class Mapper {
 
     return new ProductStoreDetails(
       productStoreDetails.basePlanId ?? null,
+      productStoreDetails.purchaseOptionId ?? null,
       productStoreDetails.productId,
       productStoreDetails.name,
       productStoreDetails.title,

--- a/plugin/src/plugin/Mapper.ts
+++ b/plugin/src/plugin/Mapper.ts
@@ -63,6 +63,7 @@ export type QProduct = {
   id: string;
   storeId: string;
   basePlanId?: string | null;
+  purchaseOptionId?: string | null;
   type: string;
   subscriptionPeriod?: QSubscriptionPeriod | null;
   trialPeriod?: QSubscriptionPeriod | null;
@@ -622,6 +623,7 @@ class Mapper {
       product.id,
       product.storeId,
       product.basePlanId ?? null,
+      product.purchaseOptionId ?? null,
       storeDetails,
       skProduct,
       offeringId,

--- a/plugin/src/plugin/Product.ts
+++ b/plugin/src/plugin/Product.ts
@@ -8,9 +8,16 @@ export class Product {
   storeId: string | null;
 
   /**
-   * Identifier of the base plan for Google product.
+   * Identifier of the base plan for a Google Play subscription product.
+   * Android only. Null for one-time products - use {@link purchaseOptionId} for those.
    */
   basePlanId: string | null;
+
+  /**
+   * Identifier of the Google Play purchase option for a one-time (in-app) product.
+   * Android only. Null for subscription products - use {@link basePlanId} for those.
+   */
+  purchaseOptionId: string | null;
 
   /**
    * Google Play Store details of this product.
@@ -63,6 +70,7 @@ export class Product {
     qonversionId: string,
     storeId: string,
     basePlanId: string | null,
+    purchaseOptionId: string | null,
     storeDetails: ProductStoreDetails | null,
     skProduct: SKProduct | null,
     offeringId: string | null,
@@ -79,6 +87,7 @@ export class Product {
     this.qonversionId = qonversionId;
     this.storeId = storeId;
     this.basePlanId = basePlanId;
+    this.purchaseOptionId = purchaseOptionId;
     this.storeDetails = storeDetails;
     this.skProduct = skProduct;
     this.offeringId = offeringId;

--- a/plugin/src/plugin/ProductStoreDetails.ts
+++ b/plugin/src/plugin/ProductStoreDetails.ts
@@ -8,10 +8,16 @@ import {ProductInAppDetails} from "./ProductInAppDetails";
  */
 export class ProductStoreDetails {
   /**
-   * Identifier of the base plan to which these details relate.
-   * Null for in-app products.
+   * Identifier of the base plan for a Google Play subscription product.
+   * Null for one-time products - use {@link purchaseOptionId} for those.
    */
   basePlanId: string | null;
+
+  /**
+   * Identifier of the Google Play purchase option for a one-time (in-app) product.
+   * Null for subscription products - use {@link basePlanId} for those.
+   */
+  purchaseOptionId: string | null;
 
   /**
    * Identifier of the subscription or the in-app product.
@@ -111,6 +117,7 @@ export class ProductStoreDetails {
 
   constructor(
     basePlanId: string | null,
+    purchaseOptionId: string | null,
     productId: string,
     name: string,
     title: string,
@@ -129,6 +136,7 @@ export class ProductStoreDetails {
     isInstallment: boolean,
   ) {
     this.basePlanId = basePlanId;
+    this.purchaseOptionId = purchaseOptionId;
     this.productId = productId;
     this.name = name;
     this.title = title;


### PR DESCRIPTION
Issue: [DEV-1215](https://linear.app/qonversion/issue/DEV-1215)

Add a dedicated `purchaseOptionId` field for one-time products, parsed from the native bridge map, mirroring `basePlanId`. `basePlanId` now carries the subscription base plan only (null for one-time); `purchaseOptionId` carries the one-time purchase option (null for subscriptions).

Runtime chain: native (android-sdk #847) → sandwich (#352, must emit the key) → this wrapper. Wrapper code is self-contained (TypeScript); the value populates once the bundled sandwich emits `purchaseOptionId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)