### PR TITLE
Release 7.8.0

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qonversion/cordova-plugin",
   "title": "Cordova Qonversion Plugin",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "description": "Qonversion provides full in-app purchases infrastructure, so you do not need to build your own server for receipt validation. Implement in-app subscriptions, validate user receipts, check subscription status, and provide access to your app features and content using our StoreKit wrapper and Google Play Billing wrapper.",
   "cordova": {
     "id": "@qonversion/cordova-plugin",

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -70,7 +70,7 @@
                 <param name="android-package" value="com.qonversion.android.sdk.NoCodesPlugin"/>
             </feature>
         </config-file>
-        <framework src="io.qonversion:sandwich:7.10.1" />
+        <framework src="io.qonversion:sandwich:7.11.0" />
         <source-file src="src/android/NoCodesPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/QonversionPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/EntitiesConverter.java" target-dir="src/com/qonversion/android/sdk" />
@@ -96,7 +96,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="QonversionSandwich" spec="7.10.1" />
+                <pod name="QonversionSandwich" spec="7.11.0" />
             </pods>
         </podspec>
     </platform>

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -1,5 +1,5 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="@qonversion/cordova-plugin" version="7.7.0">
+        id="@qonversion/cordova-plugin" version="7.8.0">
     <dependency id="cordova-annotated-plugin-android" />
     <dependency id="cordova-plugin-device" />
     <name>Qonversion</name>

--- a/plugin/src/plugin/Mapper.ts
+++ b/plugin/src/plugin/Mapper.ts
@@ -75,6 +75,7 @@ export type QProduct = {
 
 type QProductStoreDetails = {
   basePlanId?: string | null,
+  purchaseOptionId?: string | null,
   productId: string,
   name: string,
   title: string
@@ -879,6 +880,7 @@ class Mapper {
 
     return new ProductStoreDetails(
       productStoreDetails.basePlanId ?? null,
+      productStoreDetails.purchaseOptionId ?? null,
       productStoreDetails.productId,
       productStoreDetails.name,
       productStoreDetails.title,

--- a/plugin/src/plugin/Mapper.ts
+++ b/plugin/src/plugin/Mapper.ts
@@ -63,6 +63,7 @@ export type QProduct = {
   id: string;
   storeId: string;
   basePlanId?: string | null;
+  purchaseOptionId?: string | null;
   type: string;
   subscriptionPeriod?: QSubscriptionPeriod | null;
   trialPeriod?: QSubscriptionPeriod | null;
@@ -622,6 +623,7 @@ class Mapper {
       product.id,
       product.storeId,
       product.basePlanId ?? null,
+      product.purchaseOptionId ?? null,
       storeDetails,
       skProduct,
       offeringId,

--- a/plugin/src/plugin/Product.ts
+++ b/plugin/src/plugin/Product.ts
@@ -8,9 +8,16 @@ export class Product {
   storeId: string | null;
 
   /**
-   * Identifier of the base plan for Google product.
+   * Identifier of the base plan for a Google Play subscription product.
+   * Android only. Null for one-time products - use {@link purchaseOptionId} for those.
    */
   basePlanId: string | null;
+
+  /**
+   * Identifier of the Google Play purchase option for a one-time (in-app) product.
+   * Android only. Null for subscription products - use {@link basePlanId} for those.
+   */
+  purchaseOptionId: string | null;
 
   /**
    * Google Play Store details of this product.
@@ -63,6 +70,7 @@ export class Product {
     qonversionId: string,
     storeId: string,
     basePlanId: string | null,
+    purchaseOptionId: string | null,
     storeDetails: ProductStoreDetails | null,
     skProduct: SKProduct | null,
     offeringId: string | null,
@@ -79,6 +87,7 @@ export class Product {
     this.qonversionId = qonversionId;
     this.storeId = storeId;
     this.basePlanId = basePlanId;
+    this.purchaseOptionId = purchaseOptionId;
     this.storeDetails = storeDetails;
     this.skProduct = skProduct;
     this.offeringId = offeringId;

--- a/plugin/src/plugin/ProductStoreDetails.ts
+++ b/plugin/src/plugin/ProductStoreDetails.ts
@@ -8,10 +8,16 @@ import {ProductInAppDetails} from "./ProductInAppDetails";
  */
 export class ProductStoreDetails {
   /**
-   * Identifier of the base plan to which these details relate.
-   * Null for in-app products.
+   * Identifier of the base plan for a Google Play subscription product.
+   * Null for one-time products - use {@link purchaseOptionId} for those.
    */
   basePlanId: string | null;
+
+  /**
+   * Identifier of the Google Play purchase option for a one-time (in-app) product.
+   * Null for subscription products - use {@link basePlanId} for those.
+   */
+  purchaseOptionId: string | null;
 
   /**
    * Identifier of the subscription or the in-app product.
@@ -111,6 +117,7 @@ export class ProductStoreDetails {
 
   constructor(
     basePlanId: string | null,
+    purchaseOptionId: string | null,
     productId: string,
     name: string,
     title: string,
@@ -129,6 +136,7 @@ export class ProductStoreDetails {
     isInstallment: boolean,
   ) {
     this.basePlanId = basePlanId;
+    this.purchaseOptionId = purchaseOptionId;
     this.productId = productId;
     this.name = name;
     this.title = title;

--- a/plugin/src/plugin/QonversionApi.ts
+++ b/plugin/src/plugin/QonversionApi.ts
@@ -71,7 +71,7 @@ export interface QonversionApi {
    *
    * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
    *
-   * @see [Migrate offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
+   * @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
    */
   offerings(): Promise<Offerings | null>;
 

--- a/plugin/src/plugin/QonversionApi.ts
+++ b/plugin/src/plugin/QonversionApi.ts
@@ -69,7 +69,9 @@ export interface QonversionApi {
    *
    * @returns the promise with Qonversion offerings
    *
-   * @see [Offerings](https://qonversion.io/docs/offerings) for more details
+   * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
+   *
+   * @see [Migrate offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
    */
   offerings(): Promise<Offerings | null>;
 

--- a/plugin/src/plugin/QonversionInternal.ts
+++ b/plugin/src/plugin/QonversionInternal.ts
@@ -140,6 +140,11 @@ export default class QonversionInternal implements QonversionApi {
     return mappedProducts;
   }
 
+  /**
+   * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
+   *
+   * @see [Migrate offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
+   */
   async offerings(): Promise<Offerings | null> {
     let offerings = await callQonversionNative<QOfferings>('offerings');
     // noinspection UnnecessaryLocalVariableJS

--- a/plugin/src/plugin/QonversionInternal.ts
+++ b/plugin/src/plugin/QonversionInternal.ts
@@ -143,7 +143,7 @@ export default class QonversionInternal implements QonversionApi {
   /**
    * @deprecated Offerings are deprecated. Manage paywall products with Remote Configs instead: https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs
    *
-   * @see [Migrate offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
+   * @see [Migrate Offerings to Remote Configs](https://documentation.qonversion.io/docs/migrate-offerings-to-remote-configs) for more details
    */
   async offerings(): Promise<Offerings | null> {
     let offerings = await callQonversionNative<QOfferings>('offerings');

--- a/plugin/src/plugin/QonversionInternal.ts
+++ b/plugin/src/plugin/QonversionInternal.ts
@@ -32,7 +32,7 @@ import {PurchaseOptionsBuilder} from './PurchaseOptionsBuilder';
 import {SKProductDiscount} from './SKProductDiscount';
 import {PromotionalOffer} from './PromotionalOffer';
 
-const sdkVersion = "7.7.0";
+const sdkVersion = "7.8.0";
 
 export default class QonversionInternal implements QonversionApi {
 


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## What's New

— Added a separate purchaseOptionId field on Product and ProductStoreDetails for Google Play one-time products (basePlanId now stays dedicated to subscription base plans).
— Deprecated the Offerings API. Manage paywall products with Remote Configs instead.
<!-- release-notes:end -->
