### PR TITLE
feat: expose invalidateRemoteConfigsCache, bump sandwich to 7.12.0 (DEV-1236)

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -70,7 +70,7 @@
                 <param name="android-package" value="com.qonversion.android.sdk.NoCodesPlugin"/>
             </feature>
         </config-file>
-        <framework src="io.qonversion:sandwich:7.11.0" />
+        <framework src="io.qonversion:sandwich:7.12.0" />
         <source-file src="src/android/NoCodesPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/QonversionPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/EntitiesConverter.java" target-dir="src/com/qonversion/android/sdk" />
@@ -96,7 +96,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="QonversionSandwich" spec="7.11.0" />
+                <pod name="QonversionSandwich" spec="7.12.0" />
             </pods>
         </podspec>
     </platform>

--- a/plugin/src/android/QonversionPlugin.java
+++ b/plugin/src/android/QonversionPlugin.java
@@ -195,6 +195,11 @@ public class QonversionPlugin extends AnnotatedCordovaPlugin implements Qonversi
         qonversionSandwich.remoteConfigList(Utils.getResultListener(callbackContext));
     }
 
+    @PluginAction(thread = ExecutionThread.WORKER, actionName = "invalidateRemoteConfigsCache")
+    public void invalidateRemoteConfigsCache(CallbackContext callbackContext) {
+        qonversionSandwich.invalidateRemoteConfigsCache();
+    }
+
     @PluginAction(thread = ExecutionThread.WORKER, actionName = "remoteConfigListForContextKeys", isAutofinish = false)
     public void remoteConfigListForContextKeys(JSONArray contextKeys, boolean includeEmptyContextKey, CallbackContext callbackContext) {
         try {

--- a/plugin/src/android/QonversionPlugin.java
+++ b/plugin/src/android/QonversionPlugin.java
@@ -195,11 +195,6 @@ public class QonversionPlugin extends AnnotatedCordovaPlugin implements Qonversi
         qonversionSandwich.remoteConfigList(Utils.getResultListener(callbackContext));
     }
 
-    @PluginAction(thread = ExecutionThread.WORKER, actionName = "invalidateRemoteConfigsCache")
-    public void invalidateRemoteConfigsCache(CallbackContext callbackContext) {
-        qonversionSandwich.invalidateRemoteConfigsCache();
-    }
-
     @PluginAction(thread = ExecutionThread.WORKER, actionName = "remoteConfigListForContextKeys", isAutofinish = false)
     public void remoteConfigListForContextKeys(JSONArray contextKeys, boolean includeEmptyContextKey, CallbackContext callbackContext) {
         try {
@@ -209,6 +204,11 @@ public class QonversionPlugin extends AnnotatedCordovaPlugin implements Qonversi
             e.printStackTrace();
             callbackContext.error(e.getMessage());
         }
+    }
+
+    @PluginAction(thread = ExecutionThread.WORKER, actionName = "invalidateRemoteConfigsCache")
+    public void invalidateRemoteConfigsCache(CallbackContext callbackContext) {
+        qonversionSandwich.invalidateRemoteConfigsCache();
     }
 
     @PluginAction(thread = ExecutionThread.UI, actionName = "attachUserToExperiment", isAutofinish = false)

--- a/plugin/src/ios/CDVQonversionPlugin.h
+++ b/plugin/src/ios/CDVQonversionPlugin.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)storeSDKInfo:(CDVInvokedUrlCommand *)command;
 - (void)initializeSdk:(CDVInvokedUrlCommand *)command;
 - (void)syncHistoricalData:(CDVInvokedUrlCommand *)command;
+- (void)invalidateRemoteConfigsCache:(CDVInvokedUrlCommand *)command;
 - (void)syncStoreKit2Purchases:(CDVInvokedUrlCommand *)command;
 - (void)setDefinedProperty:(CDVInvokedUrlCommand *)command;
 - (void)setCustomProperty:(CDVInvokedUrlCommand *)command;

--- a/plugin/src/ios/CDVQonversionPlugin.m
+++ b/plugin/src/ios/CDVQonversionPlugin.m
@@ -90,6 +90,10 @@
     [self.qonversionSandwich syncHistoricalData];
 }
 
+- (void)invalidateRemoteConfigsCache:(CDVInvokedUrlCommand *)command {
+    [self.qonversionSandwich invalidateRemoteConfigsCache];
+}
+
 - (void)syncStoreKit2Purchases:(CDVInvokedUrlCommand *)command {
     [self.qonversionSandwich syncStoreKit2Purchases];
 }

--- a/plugin/src/plugin/QonversionApi.ts
+++ b/plugin/src/plugin/QonversionApi.ts
@@ -162,6 +162,24 @@ export interface QonversionApi {
   remoteConfigListForContextKeys(contextKeys: Array<string>, includeEmptyContextKey: boolean): Promise<RemoteConfigList>
 
   /**
+   * Invalidates the cache of remote configs so the next {@link remoteConfig} or
+   * {@link remoteConfigList} call fetches a fresh targeting evaluation from the
+   * server instead of returning the cached copy.
+   *
+   * This method performs no network request itself — it only marks the cached
+   * values as stale. An in-flight remoteConfig load is re-issued once so its
+   * waiting calls receive a fresh evaluation; an in-flight remoteConfigList
+   * completes with the evaluation it started with.
+   *
+   * Call it when the targeting inputs changed and you need the change reflected
+   * immediately, for example after setting a batch of user properties your
+   * remote config targeting depends on. You do NOT need to call it after
+   * {@link identify} — the SDK invalidates the cache on identity changes
+   * automatically. Call it after {@link initialize}.
+   */
+  invalidateRemoteConfigsCache(): void;
+
+  /**
    * This function should be used for the test purposes only. Do not forget to delete the usage of this function before the release.
    * Use this function to attach the user to the experiment.
    * @param experimentId identifier of the experiment

--- a/plugin/src/plugin/QonversionApi.ts
+++ b/plugin/src/plugin/QonversionApi.ts
@@ -175,7 +175,14 @@ export interface QonversionApi {
    * immediately, for example after setting a batch of user properties your
    * remote config targeting depends on. You do NOT need to call it after
    * {@link identify} — the SDK invalidates the cache on identity changes
-   * automatically. Call it after {@link initialize}.
+   * automatically.
+   *
+   * If the re-issued load fails, the previously received evaluation is
+   * delivered instead of an error — the call never degrades below the
+   * pre-invalidation result.
+   *
+   * Call it after {@link Qonversion.initialize}: calling before initialization
+   * throws on Android and does nothing on iOS.
    */
   invalidateRemoteConfigsCache(): void;
 

--- a/plugin/src/plugin/QonversionInternal.ts
+++ b/plugin/src/plugin/QonversionInternal.ts
@@ -256,6 +256,10 @@ export default class QonversionInternal implements QonversionApi {
     return mappedRemoteConfigList;
   }
 
+  invalidateRemoteConfigsCache () {
+    callQonversionNative('invalidateRemoteConfigsCache').then(noop);
+  }
+
   async attachUserToExperiment(experimentId: string, groupId: string): Promise<void> {
     await callQonversionNative('attachUserToExperiment', [experimentId, groupId]);
     return;


### PR DESCRIPTION
B4 exposure from the Remote Config targeting review ([dash-mono PR #674](https://github.com/qonversion/dash-mono/pull/674)). Linear: [DEV-1236](https://linear.app/qonversion/issue/DEV-1236). Exposes the new cache invalidation API released in [android-sdk 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) / [qonversion-ios-sdk 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0), bridged by [sandwich 7.12.0](https://github.com/qonversion/sandwich-sdk/releases/tag/7.12.0).

## What changed

1. **Sandwich pinned to 7.12.0** (Android + iOS). Note: the sandwich pod pins `Qonversion` exactly, so apps that also declare the native `Qonversion` pod directly must move to 6.14.0.
2. **New public API `invalidateRemoteConfigsCache`** — a void no-callback pass-through to the native method. It performs no network request; it marks the remote configs cache stale so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. An in-flight `remoteConfig` load is re-issued once so its waiting calls receive a fresh evaluation (degrading to the superseded one if the retry fails); an in-flight `remoteConfigList` completes with the evaluation it started with. You do NOT need to call it after `identify` — the SDK invalidates on identity changes automatically. Call it after initialization (calling before initialization crashes on Android and no-ops on iOS, same as the other void bridges).

## Release notes for this wrapper (minor bump)
- Source-breaking note for the release: `QonversionApi` gained a new required member — custom implementations and hand-written mocks must add `invalidateRemoteConfigsCache`.


- New: `invalidateRemoteConfigsCache` — invalidate the remote configs cache on demand (e.g. after setting a batch of user properties your targeting depends on).
- Native SDKs updated: Android 9.7.0, iOS 6.14.0 — automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4V5cx2SMU4VrfPntwfKJ9
