### PR TITLE
Release 7.9.0

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qonversion/cordova-plugin",
   "title": "Cordova Qonversion Plugin",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "description": "Qonversion provides full in-app purchases infrastructure, so you do not need to build your own server for receipt validation. Implement in-app subscriptions, validate user receipts, check subscription status, and provide access to your app features and content using our StoreKit wrapper and Google Play Billing wrapper.",
   "cordova": {
     "id": "@qonversion/cordova-plugin",

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -1,5 +1,5 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="@qonversion/cordova-plugin" version="7.8.0">
+        id="@qonversion/cordova-plugin" version="7.9.0">
     <dependency id="cordova-annotated-plugin-android" />
     <dependency id="cordova-plugin-device" />
     <name>Qonversion</name>

--- a/plugin/src/plugin/QonversionInternal.ts
+++ b/plugin/src/plugin/QonversionInternal.ts
@@ -32,7 +32,7 @@ import {PurchaseOptionsBuilder} from './PurchaseOptionsBuilder';
 import {SKProductDiscount} from './SKProductDiscount';
 import {PromotionalOffer} from './PromotionalOffer';
 
-const sdkVersion = "7.8.0";
+const sdkVersion = "7.9.0";
 
 export default class QonversionInternal implements QonversionApi {
 


### PR DESCRIPTION
Release PR

<!-- release-notes:start -->
## New

* New public API `invalidateRemoteConfigsCache` — invalidates the remote configs cache so the next `remoteConfig` / `remoteConfigList` call fetches a fresh targeting evaluation. It performs no network request itself; call it when the targeting inputs changed and you need the change reflected immediately, for example after setting a batch of user properties your targeting depends on. You do not need to call it after `identify` — the SDK invalidates the cache on identity changes automatically (#176).

## Improvements & fixes

* Native SDKs updated via QonversionSandwich 7.12.0: [Android 9.7.0](https://github.com/qonversion/android-sdk/releases/tag/sdk%2F9.7.0) and [iOS 6.14.0](https://github.com/qonversion/qonversion-ios-sdk/releases/tag/6.14.0) — automatic remote configs cache invalidation on same-uid `identify`, never-worse re-issue of superseded in-flight remote config loads, uncached bundled fallbacks with rate-limit tolerance (remote configs only) (#176).

## Breaking notes

* `QonversionApi` gained a new required member — custom implementations and hand-written mocks must add `invalidateRemoteConfigsCache`.
* The sandwich pod pins the native `Qonversion` pod exactly: apps that also declare `Qonversion` directly must move to 6.14.0.
<!-- release-notes:end -->
