### PR TITLE
feat: expose frozen Remote Config assignments

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,27 @@
+name: Checks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bridge-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: plugin/yarn.lock
+      - name: Verify frozen assignment contract
+        run: node scripts/test-frozen-assignment-contract.mjs
+      - name: Build TypeScript bridge
+        working-directory: plugin
+        run: |
+          yarn install --frozen-lockfile
+          yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Upgrade npm
         run: npm install -g npm@11.7.0
 
+      - name: Verify frozen assignment contract
+        run: node scripts/test-frozen-assignment-contract.mjs
+
       - name: Build
         run: |
           cd plugin

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -70,7 +70,7 @@
                 <param name="android-package" value="com.qonversion.android.sdk.NoCodesPlugin"/>
             </feature>
         </config-file>
-        <framework src="io.qonversion:sandwich:7.12.0" />
+        <framework src="io.qonversion:sandwich:7.13.0" />
         <source-file src="src/android/NoCodesPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/QonversionPlugin.java" target-dir="src/com/qonversion/android/sdk" />
         <source-file src="src/android/EntitiesConverter.java" target-dir="src/com/qonversion/android/sdk" />
@@ -96,7 +96,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="QonversionSandwich" spec="7.12.0" />
+                <pod name="QonversionSandwich" spec="7.13.0" />
             </pods>
         </podspec>
     </platform>

--- a/plugin/src/plugin/Mapper.ts
+++ b/plugin/src/plugin/Mapper.ts
@@ -1161,6 +1161,8 @@ class Mapper {
         return RemoteConfigurationAssignmentType.AUTO;
       case "manual":
         return RemoteConfigurationAssignmentType.MANUAL;
+      case "frozen":
+        return RemoteConfigurationAssignmentType.FROZEN;
       default:
         return RemoteConfigurationAssignmentType.UNKNOWN;
     }

--- a/plugin/src/plugin/enums.ts
+++ b/plugin/src/plugin/enums.ts
@@ -257,6 +257,7 @@ export enum RemoteConfigurationAssignmentType {
   UNKNOWN = "unknown",
   AUTO = "auto",
   MANUAL = "manual",
+  FROZEN = "frozen",
 }
 
 export enum ActionType {

--- a/scripts/test-frozen-assignment-contract.mjs
+++ b/scripts/test-frozen-assignment-contract.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const mapper = readFileSync("plugin/src/plugin/Mapper.ts", "utf8");
+const enums = readFileSync("plugin/src/plugin/enums.ts", "utf8");
+const plugin = readFileSync("plugin/plugin.xml", "utf8");
+
+assert.match(enums, /FROZEN\s*=\s*["']frozen["']/);
+assert.match(mapper, /case\s+["']frozen["']:[\s\S]*RemoteConfigurationAssignmentType\.FROZEN/);
+assert.match(mapper, /default:[\s\S]*RemoteConfigurationAssignmentType\.UNKNOWN/);
+assert.match(plugin, /io\.qonversion:sandwich:7\.13\.0/);
+assert.match(plugin, /QonversionSandwich" spec="7\.13\.0"/);
+
+console.log("Frozen assignment bridge contract is intact.");


### PR DESCRIPTION
Adds `frozen` assignment provenance to Cordova and pins Sandwich 7.13.0. Draft/stacked: merge only after qonversion/sandwich-sdk#357 is published. A static Frozen/Unknown/dependency contract now runs in pull-request CI and before package publication. The contract and plugin TypeScript build pass locally.
